### PR TITLE
feat: Add telegram_id retrieval, select groups fetches api/user-groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Um miniapp de enquetes para professores, integrado ao Telegram! Crie e gerencie 
 - **Axios** (requisições HTTP)
 - **React-Toastify** (notificações toast)
 - **Telegram Bot API** (integração com Telegram)
+- **Telegram Mini Apps SDK** (https://docs.telegram-mini-apps.com/)
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@hookform/resolvers": "^5.1.1",
+        "@telegram-apps/sdk": "^3.11.4",
         "axios": "^1.9.0",
         "bootstrap": "^5.3.6",
         "jwt-decode": "^4.0.0",
@@ -3098,6 +3099,88 @@
         "tailwindcss": "4.1.7"
       }
     },
+    "node_modules/@telegram-apps/bridge": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@telegram-apps/bridge/-/bridge-2.10.3.tgz",
+      "integrity": "sha512-mjbpxynr6g5EOQlpxuKQxDN+UTrtKLWBfJQs8BLQX0dkZVL+r7nQNAVzY2NtJHLUUCA+eUccq+yF7NkesnY46g==",
+      "license": "MIT",
+      "dependencies": {
+        "@telegram-apps/signals": "^1.1.2",
+        "@telegram-apps/toolkit": "^2.1.3",
+        "@telegram-apps/transformers": "^2.2.6",
+        "@telegram-apps/types": "^2.0.3",
+        "better-promises": "^0.4.1",
+        "error-kid": "^0.0.7",
+        "mitt": "^3.0.1",
+        "valibot": "1.0.0"
+      }
+    },
+    "node_modules/@telegram-apps/navigation": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@telegram-apps/navigation/-/navigation-1.0.14.tgz",
+      "integrity": "sha512-bqNgF/J8Po7ZtsELm3E1a6aPr7awwxO3sIqD8J6u12urOlGoW5+1KxKKbkPa58mgXuQdsltd8apI+OVy0IYiUA==",
+      "license": "MIT"
+    },
+    "node_modules/@telegram-apps/sdk": {
+      "version": "3.11.4",
+      "resolved": "https://registry.npmjs.org/@telegram-apps/sdk/-/sdk-3.11.4.tgz",
+      "integrity": "sha512-en2yRVhKJwzKfT4TOAG8fwaZHAqB2CfMCE0AY7mx55+UKlPCDdRN2BVUOxdYabUoxglJUquCUpNWr4TXIeAfng==",
+      "license": "MIT",
+      "dependencies": {
+        "@telegram-apps/bridge": "^2.10.3",
+        "@telegram-apps/navigation": "^1.0.14",
+        "@telegram-apps/signals": "^1.1.2",
+        "@telegram-apps/toolkit": "^2.1.3",
+        "@telegram-apps/transformers": "^2.2.6",
+        "@telegram-apps/types": "^2.0.3",
+        "better-promises": "^0.4.1",
+        "error-kid": "^0.0.7",
+        "valibot": "1.0.0"
+      }
+    },
+    "node_modules/@telegram-apps/signals": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@telegram-apps/signals/-/signals-1.1.2.tgz",
+      "integrity": "sha512-1P1kdCLX7MfETGPxH7f3UZKIsdE7Tz5S7QmN4Km1sbYQMakD5Bi1NecSMR7/wnHp50gWMI1JzENcMtCEmouhSg==",
+      "license": "MIT"
+    },
+    "node_modules/@telegram-apps/toolkit": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@telegram-apps/toolkit/-/toolkit-2.1.3.tgz",
+      "integrity": "sha512-LPUBL7hxQTOr+Dowyk9a1O82nQS4ja4+OYiYWtvqq5nNUHC6Gbbus0zGWCbFcj9CLnIzaeb5HWOg5iSnhoRcyg==",
+      "license": "MIT"
+    },
+    "node_modules/@telegram-apps/transformers": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@telegram-apps/transformers/-/transformers-2.2.6.tgz",
+      "integrity": "sha512-MMBRs3demeBT9Cd614KKZmak7eEyNdEbfu99a0SwEEJe2oIODjJLrUxrhUcAOc5wvTRfrKka27VXVgruauLhdg==",
+      "license": "MIT",
+      "dependencies": {
+        "@telegram-apps/toolkit": "^2.1.3",
+        "@telegram-apps/types": "^2.0.3",
+        "valibot": "1.0.0-beta.14"
+      }
+    },
+    "node_modules/@telegram-apps/transformers/node_modules/valibot": {
+      "version": "1.0.0-beta.14",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.0.0-beta.14.tgz",
+      "integrity": "sha512-tLyV2rE5QL6U29MFy3xt4AqMrn+/HErcp2ZThASnQvPMwfSozjV1uBGKIGiegtZIGjinJqn0SlBdannf18wENA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@telegram-apps/types": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@telegram-apps/types/-/types-2.0.3.tgz",
+      "integrity": "sha512-pXh9BdnLZF3e2BGc4WL+RTRMAUpqKpaSP3Rs8rB4WyRwIoRSGWFKE4gtT/9m42LGixB8YVwdo/pJ+9XO765XEA==",
+      "license": "MIT"
+    },
     "node_modules/@trysound/sax": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
@@ -3232,6 +3315,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/better-promises": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/better-promises/-/better-promises-0.4.1.tgz",
+      "integrity": "sha512-cDW7eMvhvCoWzSih5o/OxsAgTUfP05yGMq77xNZUTmcZoNU9vEeFZJ+yJJi4lnocvxFrVFKsG0Yxt7ZnuYJEig==",
+      "license": "MIT",
+      "dependencies": {
+        "error-kid": "^0.0.7"
       }
     },
     "node_modules/boolbase": {
@@ -3801,6 +3893,12 @@
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/error-kid": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/error-kid/-/error-kid-0.0.7.tgz",
+      "integrity": "sha512-8mFs7ZaDWlBFgjOy4lHLMCe2+KZfZXGx5GOgh2VQ/M1CCIvSWzbl2OMl+5fdZgrgoUfhTeF+NPhmqfEvUhN8yw==",
       "license": "MIT"
     },
     "node_modules/es-define-property": {
@@ -4508,6 +4606,12 @@
       "engines": {
         "node": ">= 18"
       }
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "license": "MIT"
     },
     "node_modules/mkdirp": {
       "version": "3.0.1",
@@ -5240,7 +5344,7 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -5345,6 +5449,20 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/valibot": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.0.0.tgz",
+      "integrity": "sha512-1Hc0ihzWxBar6NGeZv7fPLY0QuxFMyxwYR2sF1Blu7Wq7EnremwY2W02tit2ij2VJT8HcSkHAQqmFfl77f73Yw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/warning": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.1.1",
+    "@telegram-apps/sdk": "^3.11.4",
     "axios": "^1.9.0",
     "bootstrap": "^5.3.6",
     "jwt-decode": "^4.0.0",

--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -7,6 +7,9 @@ export const API_ROUTES = {
     CREATE: '/api/send-poll/',
     QUIZZ: '/api/send-quiz/'
   },
+  GROUPS: {
+    SHOW: '/api/user-groups/'
+  }
 };
 
 

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,10 +1,15 @@
-
 import 'bootstrap/dist/css/bootstrap.min.css';
 import { AppProps } from 'next/app';
 import 'react-toastify/dist/ReactToastify.css';
 import { AuthProvider } from '../shared/context/AuthContext';
+import { useEffect } from 'react';
+import { init } from '@telegram-apps/sdk';
 
 export default function MyApp({ Component, pageProps }: AppProps) {
+  useEffect(() => {
+    init();
+  }, []);
+
   return (
     <AuthProvider>
       <Component {...pageProps} />

--- a/src/pages/createPolls.tsx
+++ b/src/pages/createPolls.tsx
@@ -2,21 +2,30 @@ import api from "@/config/axios";
 import { API_ROUTES } from "@/config/routes";
 import "bootstrap/dist/css/bootstrap.min.css";
 import Image from "next/image";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { ToastContainer, toast } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 import iconPlus from "../assets/icon.png";
 import Header from "../components/Header";
 import EnqueteOption from "../components/enqueteOption";
 import Navbar from "../components/navBack";
-import grupos from "../params/grupos.json";
 import styles from "../styles/useGlobal.module.css";
+import { fetchGroups, type Group } from "../shared/Group";
 
-export default function createPolls() {
+export default function sendPoll() {
   const [question, setQuestion] = useState("");
   const [options, setOptions] = useState(["", ""]);
   const [selectedGroup, setSelectedGroup] = useState("");
   const [loading, setLoading] = useState(false);
+  const [grupos, setGrupos] = useState<Group[]>([]);
+
+  useEffect(() => {
+    const loadGroups = async () => {
+      const data = await fetchGroups();
+      if (data) setGrupos(data);
+    };
+    loadGroups();
+  }, []);
 
   const handleOptionChange = (index: any, value: any) => {
     const newOptions = [...options];
@@ -47,7 +56,7 @@ export default function createPolls() {
       return;
     }
 
-    if (options.some(opt => opt.trim() === "")) {
+    if (options.some((opt) => opt.trim() === "")) {
       toast.warn("Todas as opções devem estar preenchidas.");
       return;
     }
@@ -97,13 +106,12 @@ export default function createPolls() {
             >
               <option value="">Selecione</option>
               {grupos.map((group) => (
-                <option key={group.id} value={group.id}>
-                  {group.name}
+                <option key={group.chat_id} value={group.chat_id}>
+                  {group.title}
                 </option>
               ))}
             </select>
           </div>
-
 
           <div className="mb-4 mt-3">
             <label htmlFor="isProfessor" className={styles.label}>
@@ -141,7 +149,6 @@ export default function createPolls() {
             <button className={styles.submitPoll} type="submit" disabled={loading}>
               {loading ? "Enviando..." : "Enviar"}
             </button>
-
           </div>
         </form >
 

--- a/src/pages/createPolls.tsx
+++ b/src/pages/createPolls.tsx
@@ -12,7 +12,7 @@ import Navbar from "../components/navBack";
 import styles from "../styles/useGlobal.module.css";
 import { fetchGroups, type Group } from "../shared/Group";
 
-export default function sendPoll() {
+export default function createPoll() {
   const [question, setQuestion] = useState("");
   const [options, setOptions] = useState(["", ""]);
   const [selectedGroup, setSelectedGroup] = useState("");
@@ -112,7 +112,7 @@ export default function sendPoll() {
               ))}
             </select>
           </div>
-
+              
           <div className="mb-4 mt-3">
             <label htmlFor="isProfessor" className={styles.label}>
               Qual é a sua pergunta?

--- a/src/pages/createQuizz.tsx
+++ b/src/pages/createQuizz.tsx
@@ -3,7 +3,7 @@ import api from "@/config/axios";
 import { API_ROUTES } from "@/config/routes";
 import "bootstrap/dist/css/bootstrap.min.css";
 import Image from "next/image";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { ToastContainer, toast } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 import iconPlus from "../assets/icon.png";
@@ -11,17 +11,26 @@ import AgendamentoModal from "../components/AgendamentoModal";
 import Header from "../components/Header";
 import Navbar from "../components/navBack";
 import QuizOption from "../components/quizOption";
-import grupos from "../params/grupos.json";
 import styles from "../styles/useGlobal.module.css";
+import { fetchGroups, type Group } from "../shared/Group";
 
 export default function createQuizz() {
     const [question, setQuestion] = useState("");
     const [options, setOptions] = useState(["", ""]);
+    const [grupos, setGrupos] = useState<Group[]>([]);
     const [selectedGroup, setSelectedGroup] = useState("");
     const [correctOption, setCorrectOption] = useState<number | null>(null);
     const [loading, setLoading] = useState(false);
     const [quizData, setQuizData] = useState<any[]>([]);
     const [showModal, setShowModal] = useState(false);
+
+    useEffect(() => {
+        const loadGroups = async () => {
+        const data = await fetchGroups();
+        if (data) setGrupos(data);
+        };
+        loadGroups();
+    }, []);
 
     const handleOptionChange = (index: number, value: string) => {
         const newOptions = [...options];
@@ -142,12 +151,12 @@ export default function createQuizz() {
                             onChange={(e) => setSelectedGroup(e.target.value)}
                             required={quizData.length === 0}
                         >
-                            <option value="">Selecione</option>
-                            {grupos.map((group) => (
-                                <option key={group.id} value={group.id}>
-                                    {group.name}
-                                </option>
-                            ))}
+                        <option value="">Selecione</option>
+                        {grupos.map((group) => (
+                            <option key={group.chat_id} value={group.chat_id}>
+                            {group.title}
+                            </option>
+                        ))}
                         </select>
                     </div>
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,16 +1,27 @@
 import { APP_ROUTES } from '@/config/routes';
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
+import { retrieveLaunchParams, LaunchParams } from '@telegram-apps/sdk';
 
 export default function IndexPage() {
   const router = useRouter();
 
   useEffect(() => {
-    const timer = setTimeout(() => {
-      router.replace(APP_ROUTES.LOGIN);
-    }, 2000);
+    async function checkUser() {
+      try {
+        const params: LaunchParams = retrieveLaunchParams()
+        const user = params.tgWebAppData?.user
 
-    return () => clearTimeout(timer);
+        if (user) {
+          sessionStorage.setItem("telegram_user", JSON.stringify(user))
+        }
+      } catch (error) {
+        console.warn("Telegram user not found in launch params.");
+      }
+      router.replace(APP_ROUTES.LOGIN);
+    }
+
+    checkUser();
   }, []);
 
   return (

--- a/src/pages/register.tsx
+++ b/src/pages/register.tsx
@@ -29,10 +29,18 @@ export default function Register() {
 
 
   const onSubmit = async (data: RegisterSchemaInput) => {
+    const rawTelegramUser = sessionStorage.getItem("telegram_user");
+    const parsedTelegramUser = rawTelegramUser ? JSON.parse(rawTelegramUser) : null;
+
     const formattedData = {
       ...data,
       is_professor: String(data.is_professor) === "true" ? true : false,
     };
+
+    if (parsedTelegramUser?.id) {
+      formattedData.telegram_id = parsedTelegramUser.id;
+    }
+
     try {
       setLoading(true);
       const response = await api.post(API_ROUTES.AUTH.REGISTER, formattedData);

--- a/src/schemas/registerSchema.ts
+++ b/src/schemas/registerSchema.ts
@@ -8,6 +8,7 @@ export const baseRegisterSchema = z.object({
         required_error: "Selecione se você é professor",
         invalid_type_error: "Selecione se você é professor",
     }),
+    telegram_id: z.number().optional(),
 });
 
 export type RegisterSchemaInput = z.input<typeof baseRegisterSchema>; 

--- a/src/shared/Group.tsx
+++ b/src/shared/Group.tsx
@@ -1,0 +1,20 @@
+import api from "@/config/axios";
+import { API_ROUTES } from "@/config/routes";
+import { toast } from "react-toastify";
+import "react-toastify/dist/ReactToastify.css";
+
+export type Group = {
+  id: number;
+  title: string;
+  chat_id: string;
+  fetch_date: string;
+};
+
+export const fetchGroups = async (): Promise<Group[] | undefined> => {
+  try {
+    return await api.get(API_ROUTES.GROUPS.SHOW);
+  } catch (error: any) {
+    toast.error("Erro ao recuperar grupos");
+    console.error(error);
+  }
+};


### PR DESCRIPTION
**Observações**

Adicionei uma lib que facilita interação com miniapps: [telegram-miniapps](https://docs.telegram-mini-apps.com/packages/telegram-apps-sdk/3-x)

Como o init() é chamado no _app.tsx, ele acaba quebrando o acesso externo ao Telegram no frontend, pois é necessária a injeção do contexto do miniapp, o que só ocorre quando o app é aberto pelo Telegram, seja por botão menu, mensagem inline ou botão mini app mesmo. 

Sem essa injeção, não é possível capturar o telegram_id durante o registro, a listagem de grupos dinamica foi adicionada em createPolls e createQuizz e é obtida via api e jwt e não telegram_id e, portanto, não é afetado.

Não consegui testar o createQuizz com o backend local, tive uns problemas de agendamento com o Celery, mesmo quando tentava enviar imediatamente. Preciso testar em produção.

Teste feito no @ajaxquiz_bot

<img width="760" height="727" alt="cadastro" src="https://github.com/user-attachments/assets/b43c1dc7-b226-4fd3-9b24-b76639ed6eaa" />

<img width="1166" height="299" alt="post_cadastro" src="https://github.com/user-attachments/assets/e4507cd0-62ba-4722-bccf-4065072df892" />

<img width="479" height="683" alt="grupos_enquete" src="https://github.com/user-attachments/assets/5984f796-da23-4947-ae70-72913c93353e" />

<img width="1683" height="953" alt="resultado_enquete" src="https://github.com/user-attachments/assets/c975d28e-177b-4ae3-ab8a-bce1e5259f0c" />

